### PR TITLE
Standardize GraphLAMA paper readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,40 @@
-# Enable Self-supervised Fine-tuning on GFM
+# GraphLAMA: Enabling Efficient Adaptation of Graph Language Models with Limited Annotations
 
-# <center><img src="images/framework.jpg" style="width: 80%"> </center>
-
+This repository contains the official implementation and resources for GraphLAMA, an approach for efficiently adapting graph language models with limited annotations. The paper has been accepted to KDD 2025.
 
 ### 1. Environment Preparation
 ```shell
-conda create -n graphgpt python=3.8
+# Python
+conda create -n graphlama python=3.8
+conda activate graphlama
 
-conda activate graphgpt
-
-# Torch with CUDA 11.7
+# PyTorch with CUDA 11.7
 pip install torch==1.13.0+cu117 torchvision==0.14.0+cu117 torchaudio==0.13.0 --extra-index-url https://download.pytorch.org/whl/cu117
-# To support vicuna base model
+
+# Optional: support for Vicuna base model via FastChat
 pip3 install "fschat[model_worker,webui]"
-# To install pyg and pyg-relevant packages
+
+# PyG and related packages (for torch 1.13.0 + cu117)
 pip install torch_geometric
 pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-1.13.0+cu117.html
-# Clone our GraphGPT
-git clone https://github.com/HKUDS/GraphGPT.git
-cd GraphGPT
-# Install required libraries
+
+# Project dependencies
 pip install -r requirements.txt
 ```
-### 2. Prepare Models and data
-Prepare base model Vicuna, please download its weights [here](https://github.com/lm-sys/FastChat#model-weights).
-Prepare pre-training data follow GraphGPT/data from https://github.com/HKUDS/GraphGPT.
-Prepare test-time tuning data follow our code presented in data/cora/reshape_cora.py.
+
+### 2. Prepare Models and Data
+- Base LLM weights (if applicable): Vicuna weights are available from the FastChat project: [link](https://github.com/lm-sys/FastChat#model-weights).
+- Pre-training data: we follow the data format used in GraphGPT; please refer to their data preparation instructions at [GraphGPT](https://github.com/HKUDS/GraphGPT).
+- Test-time tuning data: see `data/cora/reshape_cora.py` for an example pipeline.
+
 ### 3. Pre-training Stage
 ```shell
 cd path/to/grapht3
 sh ./scripts/tune_script/stage1.sh
 sh ./scripts/tune_script/stage2.sh
 ```
-### 4. Test-time tuning Stage
+
+### 4. Test-time Tuning Stage
 ```shell
 cd path/to/grapht3
 sh ./scripts/tune_script/SFTonGFM_train.sh
@@ -44,5 +46,24 @@ cd path/to/grapht3
 sh ./scripts/tune_script/SFTonGFM_eval.sh
 ```
 
-### 6. Note
- Our code is based on the GraphGPT framework https://github.com/HKUDS/GraphGPT, but have made significant modifications to the model, training process, and data, as shown in the framework figure we provided. We appreciate GraphGPT's outstanding work
+### 6. Paper
+- Title: GraphLAMA: Enabling Efficient Adaptation of Graph Language Models with Limited Annotations
+- Venue: KDD 2025
+- Preprint: coming soon
+
+### 7. Citation
+If you find this repository useful, please cite our paper (BibTeX coming soon):
+```
+@inproceedings{graphlama_kdd2025,
+  title     = {GraphLAMA: Enabling Efficient Adaptation of Graph Language Models with Limited Annotations},
+  author    = {To be updated},
+  booktitle = {Proceedings of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
+  year      = {2025}
+}
+```
+
+### 8. Acknowledgements
+This work builds upon open-source efforts, including the GraphGPT framework: https://github.com/HKUDS/GraphGPT. We thank the authors and community for their contributions.
+
+### 9. License
+This project is released under the license specified in `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -85,19 +85,5 @@ sh ./scripts/tune_script/SFTonGFM_eval.sh
 - Venue: KDD 2025
 - Preprint: [arXiv:2506.21559](https://arxiv.org/pdf/2506.21559)
 
-### 8. Citation
-If you find this repository useful, please cite our paper (BibTeX coming soon):
-```
-@inproceedings{graphlama_kdd2025,
-  title     = {GraphLAMA: Enabling Efficient Adaptation of Graph Language Models with Limited Annotations},
-  author    = {To be updated},
-  booktitle = {Proceedings of the ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD)},
-  year      = {2025}
-}
-```
-
-### 9. Acknowledgements
+### 8. Acknowledgements
 This work builds upon open-source efforts, including the GraphGPT framework: https://github.com/HKUDS/GraphGPT. We thank the authors and community for their contributions.
-
-### 10. License
-This project is released under the license specified in `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -46,12 +46,46 @@ cd path/to/grapht3
 sh ./scripts/tune_script/SFTonGFM_eval.sh
 ```
 
-### 6. Paper
+### 6. Code Structure
+```
+.
+├─ grapht3/                 # Core GraphLAMA package
+│  ├─ model/                # Model registry and graph layers
+│  │  └─ graph_layers/      # GNN modules, tokenizer, CLIP-graph
+│  ├─ train/                # Training entry points and trainers
+│  ├─ serve/                # Serving and web UI (FastChat-style)
+│  ├─ eval/                 # Evaluation utilities
+│  ├─ protocol/             # API protocol definitions
+│  ├─ conversation.py
+│  ├─ constants.py
+│  └─ utils.py
+├─ scripts/                 # Shell scripts for training/eval/serving
+│  ├─ tune_script/          # Stage1/2, SFT training/eval scripts
+│  ├─ eval_script/
+│  └─ serving/
+├─ text-graph-grounding/    # Graph-text grounding components and data utils
+│  ├─ data/
+│  ├─ graph_transformer.py
+│  ├─ model_gt.py
+│  └─ main_train.py
+├─ reshape_wikics/          # Data reshaping for WikiCS
+├─ reshape_products/        # Data reshaping for OGBN-Products
+├─ data/                    # Example dataset (e.g., cora)
+├─ tests/                   # Tests
+├─ playground/              # Playground experiments
+├─ output_eva_cora/         # Example outputs
+├─ Pure_GNN_Cora.py         # GNN baseline example
+├─ task_embedding_generate.py
+├─ requirements.txt
+└─ README.md
+```
+
+### 7. Paper
 - Title: GraphLAMA: Enabling Efficient Adaptation of Graph Language Models with Limited Annotations
 - Venue: KDD 2025
-- Preprint: coming soon
+- Preprint: [arXiv:2506.21559](https://arxiv.org/pdf/2506.21559)
 
-### 7. Citation
+### 8. Citation
 If you find this repository useful, please cite our paper (BibTeX coming soon):
 ```
 @inproceedings{graphlama_kdd2025,
@@ -62,8 +96,8 @@ If you find this repository useful, please cite our paper (BibTeX coming soon):
 }
 ```
 
-### 8. Acknowledgements
+### 9. Acknowledgements
 This work builds upon open-source efforts, including the GraphGPT framework: https://github.com/HKUDS/GraphGPT. We thank the authors and community for their contributions.
 
-### 9. License
+### 10. License
 This project is released under the license specified in `LICENSE`.


### PR DESCRIPTION
Standardize `README.md` to reflect the GraphLAMA paper for KDD 2025, removing model figures and unifying model naming.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ee7ea6c-ed98-4ef9-890a-294039773b60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ee7ea6c-ed98-4ef9-890a-294039773b60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

